### PR TITLE
Fix test failures by adding submodule initialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -48,4 +48,14 @@ func main() {
 }
 ```
 
+## Development Setup
+
+This project uses git submodules for test data. After cloning the repository, initialize the submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+This will pull the test cases from the `huml-lang/tests` repository into the `tests/` directory.
+
 MIT License

--- a/decode_test.go
+++ b/decode_test.go
@@ -52,6 +52,11 @@ func TestAssertions(t *testing.T) {
 		Error bool   `json:"error"`
 	}
 
+	// Check if the tests/assertions directory exists
+	if _, err := os.Stat("./tests/assertions"); os.IsNotExist(err) {
+		t.Fatalf("tests/assertions directory not found. Please run 'git submodule update --init --recursive' to initialize test data. See README for development setup instructions.")
+	}
+
 	err := filepath.Walk("./tests/assertions", func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
 			return nil


### PR DESCRIPTION
## Summary
- Add development setup section to README with git submodule instructions
- Add directory existence check in decode_test.go with helpful error message  
- Fix GitHub Actions workflow to checkout submodules recursively

## Test plan
- [x] Tests pass locally after running `git submodule update --init --recursive`
- [x] GitHub Actions workflow will now initialize submodules automatically
- [x] Clear error message guides developers to initialize submodules when missing