### PR TITLE
add key start check

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -458,6 +458,9 @@ func (p *parser) parseInlineVectorContents(typ dataType) (any, error) {
 	if typ == typeInlineDict {
 		res := map[string]any{}
 		_, err := p.parseInlineItems(res, func() (any, error) {
+			if !p.isKeyStart() {
+				return nil, p.errorf("invalid character '%c', expected key", p.data[p.pos])
+			}
 			key, err := p.parseKey()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
fix below test cases
```json
{"name": "inline_dict_invalid_key", "input": "dict:: 1: true", "error": true},
{"name": "inline_dict_invalid_key", "input": "dict:: _a: true", "error": true},
```

related to: https://github.com/huml-lang/tests/pull/2