### PR TITLE
fix: undefined var out

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -465,7 +465,7 @@ func (p *parser) parseInlineVectorContents(typ dataType) (any, error) {
 			if p.done() || p.data[p.pos] != ':' {
 				return nil, p.errorf("expected ':' in inline dict")
 			}
-			if _, exists := out[key]; exists {
+			if _, exists := res[key]; exists {
 				return nil, p.errorf("duplicate key '%s' in dict", key)
 			}
 


### PR DESCRIPTION
Build was failing:

```
# github.com/huml-lang/go-huml [github.com/huml-lang/go-huml.test]
./decode.go:460:3: declared and not used: out
./decode.go:468:20: undefined: out
FAIL	github.com/huml-lang/go-huml [build failed]
```