### PR TITLE
Fix decode bug, add example tests, and update README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@ import (
 )
 
 func main() {
-	var result map[string]any
-	if err := Unmarshal([]byte(doc), &result); err != nil {
-		panic(err)
-	}
+    doc := `
+name: "Alice"
+age: 30
+active: true
+`
+    var result map[string]any
+    if err := huml.Unmarshal([]byte(doc), &result); err != nil {
+        panic(err)
+    }
 
-	fmt.Println(v)
+    fmt.Println(result["name"])   // Alice
+    fmt.Println(result["age"])    // 30
+    fmt.Println(result["active"]) // true
 }
 ```
 
@@ -39,14 +46,27 @@ import (
 )
 
 func main() {
-	res, err := Marshal(stuff);
-	if err != nil {
-		panic(err)
-	}
+    data := map[string]any{
+        "name":   "Alice",
+        "age":    30,
+        "active": true,
+    }
 
-	fmt.Println(string(res))
+    res, err := huml.Marshal(data)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(string(res))
+    // Output:
+    // %HUML v0.1.0
+    // active: true
+    // age: 30
+    // name: "Alice"
 }
 ```
+
+See the [package documentation](https://pkg.go.dev/github.com/huml-lang/go-huml) for more examples and API reference.
 
 ## Development Setup
 

--- a/decode.go
+++ b/decode.go
@@ -465,7 +465,7 @@ func (p *parser) parseInlineVectorContents(typ dataType) (any, error) {
 			if p.done() || p.data[p.pos] != ':' {
 				return nil, p.errorf("expected ':' in inline dict")
 			}
-			if _, exists := out[key]; exists {
+			if _, exists := res[key]; exists {
 				return nil, p.errorf("duplicate key '%s' in dict", key)
 			}
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,47 @@
+package huml_test
+
+import (
+	"fmt"
+
+	"github.com/huml-lang/go-huml"
+)
+
+func ExampleUnmarshal() {
+	doc := `
+name: "Alice"
+age: 30
+active: true
+`
+	var result map[string]any
+	if err := huml.Unmarshal([]byte(doc), &result); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(result["name"])
+	fmt.Println(result["age"])
+	fmt.Println(result["active"])
+	// Output:
+	// Alice
+	// 30
+	// true
+}
+
+func ExampleMarshal() {
+	data := map[string]any{
+		"name":   "Alice",
+		"age":    30,
+		"active": true,
+	}
+
+	res, err := huml.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(res))
+	// Output:
+	// %HUML v0.1.0
+	// active: true
+	// age: 30
+	// name: "Alice"
+}


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in decode.go and improves the documentation with working examples.

## Changes
- **Fixed decode.go:468**: Changed `out[key]` to `res[key]` which was causing a build failure due to undefined variable
- **Added example_test.go**: Created proper Go example tests for `ExampleUnmarshal` and `ExampleMarshal` that will appear on pkg.go.dev
- **Updated README.md**: Replaced broken examples with working ones that properly use the `huml` package prefix and include expected output

## Test plan
- All existing tests pass
- New example tests pass and demonstrate correct usage