### PR TITLE
feat: Add comprehensive struct tag support with omitempty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,94 @@ func main() {
 }
 ```
 
+### Struct Tags
+
+The library supports struct tags for customizing field names and behavior, similar to `encoding/json`:
+
+#### Field Renaming
+
+Use the `huml` tag to specify a custom field name in the HUML output:
+
+```go
+type User struct {
+    FirstName string `huml:"first_name"`
+    LastName  string `huml:"last_name"`
+    Age       int    `huml:"age"`
+}
+```
+
+#### Skipping Fields
+
+Use `huml:"-"` to skip a field during marshalling:
+
+```go
+type Config struct {
+    PublicKey  string `huml:"public_key"`
+    PrivateKey string `huml:"-"` // This field will be skipped
+}
+```
+
+#### Omit Empty Values
+
+Use the `omitempty` option to skip fields with zero/empty values:
+
+```go
+type Profile struct {
+    Name     string  `huml:"name"`
+    Email    string  `huml:"email,omitempty"`    // Omitted if empty
+    Age      int     `huml:"age,omitempty"`     // Omitted if 0
+    Bio      string  `huml:"bio,omitempty"`      // Omitted if empty
+    Tags     []string `huml:"tags,omitempty"`     // Omitted if empty slice
+    Metadata map[string]string `huml:"metadata,omitempty"` // Omitted if empty map
+}
+```
+
+When marshalling, fields with `omitempty` are skipped if they are:
+- Empty strings (`""`)
+- Zero numeric values (`0`, `0.0`)
+- `false` booleans
+- `nil` pointers
+- Empty slices, arrays, or maps
+- Structs where all exported fields are empty
+
+#### Complete Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/huml-lang/go-huml"
+)
+
+type Person struct {
+    Name        string   `huml:"name"`
+    Age         int      `huml:"age,omitempty"`
+    Email       string   `huml:"email,omitempty"`
+    SecretToken string   `huml:"-"` // Never marshalled
+    Tags        []string `huml:"tags,omitempty"`
+}
+
+func main() {
+    person := Person{
+        Name:        "Alice",
+        Age:         0,        // Will be omitted
+        Email:       "",       // Will be omitted
+        SecretToken: "secret", // Will be skipped
+        Tags:        []string{"developer", "golang"},
+    }
+
+    data, _ := huml.Marshal(person)
+    fmt.Println(string(data))
+    // Output:
+    // %HUML v0.1.0
+    // name: "Alice"
+    // tags::
+    //   - "developer"
+    //   - "golang"
+}
+```
+
 See the [package documentation](https://pkg.go.dev/github.com/huml-lang/go-huml) for more examples and API reference.
 
 ## Development Setup

--- a/decode.go
+++ b/decode.go
@@ -1241,20 +1241,15 @@ func setStruct(d reflect.Value, src any) error {
 	return nil
 }
 
-// getFieldName returns the field name to use for mapping, checking for struct tags
+// getFieldName returns the field name to use for mapping, checking for struct tags.
+// It uses the shared parseStructTag function for consistency with encoding.
+// Note: omitempty is only relevant for encoding, so we ignore it here.
 func getFieldName(field reflect.StructField) string {
-	if tag := field.Tag.Get("huml"); tag != "" {
-		if tag == "-" {
-			return "-"
-		}
-
-		// Handle comma-separated options (name,omitempty)
-		parts := strings.Split(tag, ",")
-		return parts[0]
+	name, _ := parseStructTag(field.Tag)
+	if name == "" {
+		return field.Name
 	}
-
-	// Default to field name.
-	return field.Name
+	return name
 }
 
 // setSlice unmarshals an array into a slice.

--- a/example_test.go
+++ b/example_test.go
@@ -45,3 +45,59 @@ func ExampleMarshal() {
 	// age: 30
 	// name: "Alice"
 }
+
+func ExampleMarshal_structTags() {
+	// Struct tags allow you to customize field names and behavior
+	type Person struct {
+		Name        string   `huml:"name"`
+		Age         int      `huml:"age,omitempty"` // Omitted if zero
+		Email       string   `huml:"email,omitempty"`
+		SecretToken string   `huml:"-"` // Always skipped
+		Tags        []string `huml:"tags,omitempty"`
+	}
+
+	person := Person{
+		Name:        "Alice",
+		Age:         0,        // Will be omitted
+		Email:       "",       // Will be omitted
+		SecretToken: "secret", // Will be skipped
+		Tags:        []string{"developer", "golang"},
+	}
+
+	res, err := huml.Marshal(person)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(res))
+	// Output:
+	// %HUML v0.1.0
+	// name: "Alice"
+	// tags::
+	//   - "developer"
+	//   - "golang"
+}
+
+func ExampleUnmarshal_structTags() {
+	// Struct tags work for unmarshalling too - they map HUML keys to struct fields
+	type User struct {
+		FirstName string `huml:"first_name"`
+		LastName  string `huml:"last_name"`
+		Age       int    `huml:"age"`
+	}
+
+	doc := `
+first_name: "Alice"
+last_name: "Smith"
+age: 30
+`
+
+	var user User
+	if err := huml.Unmarshal([]byte(doc), &user); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Name: %s %s, Age: %d\n", user.FirstName, user.LastName, user.Age)
+	// Output:
+	// Name: Alice Smith, Age: 30
+}


### PR DESCRIPTION
This commit implements full struct tag support for the huml package.

Features added:
- Parse struct tags with comma-separated options (e.g., name,omitempty)
- Extract custom field names from huml tags
- Implement omitempty option to skip zero/empty values during marshalling
- Support for skipping fields with huml:- tag
- Proper empty value detection for all Go types (strings, numbers, bools, pointers, slices, maps, arrays, nested structs)
- Consistent tag parsing between encoding and decoding

Implementation details:
- Added parseStructTag() helper function for tag parsing
- Added isEmptyValue() helper function for zero value detection
- Updated marshalStruct() to respect omitempty and custom field names
- Updated getFieldName() in decode.go to use shared tag parsing logic
- Added comprehensive test coverage (TestStructTags) with 10+ test cases
- Updated documentation in README.md and example_test.go

This addresses the GitHub issue requesting struct tag support and makes the library production-ready for struct-based workflows.

Test coverage:
- Field renaming with custom names
- Omitempty with zero values (strings, ints, bools)
- Omitempty with collections (slices, maps)
- Omitempty with pointers (nil vs non-nil)
- Omitempty with nested structs
- Skipping fields with huml:-
- Round-trip marshalling/unmarshalling
- Edge cases and error handling

Breaking changes: None (backward compatible)