### PR TITLE
Encode strings the decoder can read back

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -372,32 +372,30 @@ func (s *state) marshalSlice(v reflect.Value, indent int) {
 
 // marshalString handles both single-line and multi-line strings.
 func (s *state) marshalString(str string, indent int) {
-	// If a string contains a newline, it must be formatted as a multi-line string.
-	// We use """ to preserve all whitespace as per the spec.
+	// A string containing a newline must use a multi-line """ block to stay lossless.
 	if strings.Contains(str, "\n") {
-		// The `indent` passed here is the indentation for the value, which is key_indent + 2.
-		// The content of the multi-line string must be at key_indent + 2.
-		// The closing delimiter must be at key_indent.
+		// The closing delimiter sits at the key indent, content one level (2 spaces)
+		// deeper. At the document root indent is 0, so clamp to avoid a negative repeat.
 		keyIndent := indent - 2
-		contentIndent := indent
+		if keyIndent < 0 {
+			keyIndent = 0
+		}
+		contentIndent := keyIndent + 2
 
 		s.write("\"\"\"\n")
-		lines := strings.Split(str, "\n")
-		// The last line of a multi-line string from split can be empty if the string ends with a newline.
-		// We trim this to avoid an extra trailing newline inside the HUML block.
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			lines = lines[:len(lines)-1]
-		}
-		for _, line := range lines {
-			s.write(strings.Repeat(" ", contentIndent))
-			s.write(line)
+		// Split is the exact inverse of the decoder's line-join: emit every line,
+		// including a trailing empty one, so genuine trailing newlines survive.
+		for _, line := range strings.Split(str, "\n") {
+			if line != "" {
+				s.write(strings.Repeat(" ", contentIndent))
+				s.write(line)
+			}
 			s.write("\n")
 		}
 		s.write(strings.Repeat(" ", keyIndent))
 		s.write("\"\"\"")
 	} else {
-		// Standard Go quoting handles all necessary escapes for a valid HUML string.
-		s.write(strconv.Quote(str))
+		s.write(humlQuote(str))
 	}
 }
 
@@ -469,7 +467,40 @@ func quoteKeyIfNeeded(key string) string {
 	if bareKeyRegex.MatchString(key) {
 		return key
 	}
-	return strconv.Quote(key)
+	return humlQuote(key)
+}
+
+// humlQuote returns the HUML double-quoted form of s. The spec permits only the
+// escapes \" \\ \b \f \n \r \t \v and forbids \x/\u/\U, so every other byte,
+// control characters included, is written literally in its canonical form.
+func humlQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; c {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\v':
+			b.WriteString(`\v`)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 // indirect walks down a chain of pointers and interfaces to find the underlying

--- a/encode_string_test.go
+++ b/encode_string_test.go
@@ -1,0 +1,100 @@
+package huml
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// roundTrip marshals v, decodes it back and asserts the value survives. The
+// library's own decoder is the oracle: the encoder must never emit bytes its
+// decoder rejects, and the value must be preserved exactly.
+func roundTrip(t *testing.T, name string, v any) {
+	t.Helper()
+	b, err := Marshal(v)
+	if !assert.NoError(t, err, "%s: marshal", name) {
+		return
+	}
+	var out any
+	if !assert.NoError(t, Unmarshal(b, &out), "%s: decoder rejected encoder output\n%s", name, b) {
+		return
+	}
+	assert.Equal(t, fmt.Sprint(v), fmt.Sprint(out), "%s: value changed on round-trip\n%s", name, b)
+}
+
+// Every byte must survive a round-trip as a single-line string value. C0
+// controls, DEL, ESC and bell previously produced \x/\u/\a escapes the decoder
+// could not read.
+func TestEncodeStringAllBytesValue(t *testing.T) {
+	for i := 0; i < 256; i++ {
+		s := "a" + string([]byte{byte(i)}) + "b"
+		roundTrip(t, fmt.Sprintf("value-byte-0x%02x", i), map[string]any{"k": s})
+	}
+}
+
+// Quoted keys go through the same escaping path as values (the sibling site) and
+// must round-trip for every byte too. A newline in a key uses the \n escape,
+// since a key is never a multi-line block.
+func TestEncodeStringAllBytesKey(t *testing.T) {
+	for i := 0; i < 256; i++ {
+		k := "a" + string([]byte{byte(i)}) + "b"
+		roundTrip(t, fmt.Sprintf("key-byte-0x%02x", i), map[string]any{k: "v"})
+	}
+}
+
+// Encoded output must not contain the escapes HUML forbids (\x, \u, \U, \a).
+func TestEncodeStringNoForbiddenEscapes(t *testing.T) {
+	b, err := Marshal(map[string]any{"k": "\x00\a\b\x1b\x7f\xff"})
+	assert.NoError(t, err)
+	for _, bad := range []string{`\x`, `\u`, `\U`, `\a`} {
+		assert.NotContains(t, string(b), bad, "emitted forbidden escape %s\n%s", bad, b)
+	}
+}
+
+// A normal string must not gain spurious escapes (over-escaping guard).
+func TestEncodeStringNoOverEscape(t *testing.T) {
+	assert.Equal(t, `"hello world / a.b-c"`, humlQuote("hello world / a.b-c"))
+	assert.Equal(t, `"tab\ttab \"q\" \\slash"`, humlQuote("tab\ttab \"q\" \\slash"))
+}
+
+// Multi-line strings must preserve trailing and interior newlines. The encoder
+// used to drop a genuine trailing newline (data loss).
+func TestEncodeStringMultilineEdges(t *testing.T) {
+	cases := map[string]string{
+		"trailing-newline":    "a\n",
+		"two-trailing":        "a\n\n",
+		"leading-newline":     "\na",
+		"only-newline":        "\n",
+		"blank-middle":        "a\n\nb",
+		"interior-indent":     "a\n  b\n",
+		"crlf":                "a\r\nb",
+		"no-trailing-newline": "a\nb",
+	}
+	for name, s := range cases {
+		roundTrip(t, name, map[string]any{"k": s})
+	}
+}
+
+// A multi-line string at the document root must not panic (indent 0 underflowed
+// strings.Repeat) and must round-trip.
+func TestEncodeStringRootMultiline(t *testing.T) {
+	for name, v := range map[string]any{
+		"root-multiline":        "line1\nline2",
+		"root-trailing-newline": "a\nb\n",
+		"root-control":          "a\x1bb",
+		"root-plain":            "hello",
+	} {
+		roundTrip(t, name, v)
+	}
+}
+
+// Agreeing controls: values the encoder already handled correctly must stay green,
+// proving the harness is discriminating rather than failing everything.
+func TestEncodeStringControls(t *testing.T) {
+	roundTrip(t, "plain", map[string]any{"k": "hello"})
+	roundTrip(t, "unicode", map[string]any{"k": "Hello 🌏 café"})
+	roundTrip(t, "float-exp", map[string]any{"k": 1e20})
+	roundTrip(t, "small-float", map[string]any{"k": 1e-7})
+	roundTrip(t, "multiline-no-trailer", map[string]any{"k": "line1\nline2"})
+}


### PR DESCRIPTION
The encoder emits output its own decoder rejects. `marshalString` and `quoteKeyIfNeeded` both quote via `strconv.Quote`, which produces `\x`, `\u` and `\a` escapes. HUML permits only `\" \\ \b \f \n \r \t \v` and forbids `\u`/`\U`/`\x` (v0.2.0 spec, "Strings"), so any control/DEL/ESC/bell byte fails to round-trip with `invalid escape character`:

```go
b, _ := huml.Marshal(map[string]any{"k": "\x1b[0m"})
var out map[string]any
err := huml.Unmarshal(b, &out) // line 2: invalid escape character '\x'
```

Both quoting sites now share a HUML-conformant escaper that emits only the spec escapes and writes every other byte literally, its canonical form. The spec has no named escape for bytes like NUL/ESC/DEL; the single-line grammar `("\"" | [^ '\n' '"'])*` accepts them raw and the decoder already reads them that way, so the encoder now writes them literally.

Two more multi-line defects in the same function, also fixed: a genuine trailing newline was dropped (`"a\n"` decoded back to `"a"`), and a root-level multi-line string panicked (`Marshal("line1\nline2")` -> `strings: negative Repeat count`, from `keyIndent = indent - 2` underflowing at indent 0).

Tested with a round-trip over all 256 byte values as both values and keys, the multi-line edge cases and root scalars; the existing suite is unchanged. `go test ./...` is green.
